### PR TITLE
Improve -h help output for bklg commands

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -90,6 +90,12 @@ bklg issue writeComment PROJ-123 -m "受け入れ条件を満たす修正を入�
 
 詳細は `docs/spec.md` を参照してください。
 
+## ヘルプ活用
+
+- `bklg <command> -h` で、使い方と実行例を確認できます。
+- サブコマンドのヘルプにも `--format` / `--space` / `--api-key` など共通オプションが表示されます。
+- `bklg auth login -h` では必須入力（`--space`, `--api-key`）と `--host` の指定例を確認できます。
+
 ## 設定
 
 優先順位（高い順）

--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ bklg issue writeComment PROJ-123 -m "Please review the fix."
 
 See `docs/spec.md` for the full CLI spec.
 
+## Help Tips
+
+- Use `bklg <command> -h` to see usage with examples.
+- Subcommand help also shows global options like `--format`, `--space`, and `--api-key`.
+- `bklg auth login -h` explains required inputs (`--space`, `--api-key`) and host examples.
+
 ## Configuration
 
 Priority order (highest first):

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -54,6 +54,12 @@
 - `--host <backlog.jp|backlog.com|...>`（既定：config/env/`backlog.jp`）
 - `--api-key <key>`（既定：config/env）
 
+`-h` / `--help` は各サブコマンドでも利用でき、次を表示すること:
+
+- そのコマンドの `Usage`
+- 親コマンドの共通オプション（Global Options）
+- 実行例（Examples）と注意事項（必要な入力、排他オプションなど）
+
 ### 2.2 auth
 
 #### 2.2.1 `bklg auth login`

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -33,14 +33,34 @@ import { err, isNonEmptyString, ok, toError, type Result } from "../utils/index.
 
 const program = new Command();
 
+const rootHelpText = `
+Auth resolution order (highest first):
+  1) CLI args: --space, --host, --api-key
+  2) Env vars: BACKLOG_SPACE, BACKLOG_HOST, BACKLOG_API_KEY
+  3) Config file: ~/.config/bklg/config.json
+
+Output format:
+  md    AI/editor-friendly structured Markdown
+  json  Backlog API-like JSON output (default)
+  text  Compact human-readable text
+
+Examples:
+  $ bklg auth login --space your-space --api-key YOUR_API_KEY
+  $ bklg issue view PROJ-123 --format md
+  $ bklg issue search --project 123 --status 1 --assignee me --format text
+`;
+
 program
   .name("bklg")
   .description("Backlog API v2 thin wrapper CLI")
-  .option("--format <format>", "output format (md|json|text)", "json")
+  .configureHelp({ showGlobalOptions: true })
+  .showSuggestionAfterError(true)
+  .addOption(new Option("--format <format>", "output format").choices(["md", "json", "text"]).default("json"))
   .option("--debug", "show debug logging", false)
-  .addOption(new Option("--space <space>", "backlog space").env("BACKLOG_SPACE"))
-  .addOption(new Option("--host <host>", "backlog host").env("BACKLOG_HOST"))
-  .addOption(new Option("--api-key <key>", "backlog api key").env("BACKLOG_API_KEY"));
+  .addOption(new Option("--space <space>", "backlog space (required for authenticated commands)").env("BACKLOG_SPACE"))
+  .addOption(new Option("--host <host>", "backlog host (e.g. backlog.jp, backlog.com)").env("BACKLOG_HOST"))
+  .addOption(new Option("--api-key <key>", "backlog api key (required for authenticated commands)").env("BACKLOG_API_KEY"))
+  .addHelpText("after", rootHelpText);
 
 const auth = program.command("auth").description("Authentication commands");
 const issue = program.command("issue").description("Issue commands");
@@ -296,6 +316,18 @@ const parseNotifyIds = (value: string | undefined): Result<number[]> => {
 auth
   .command("login")
   .description("Save API key to local config")
+  .usage("--space <space> [--host <host>] --api-key <key>")
+  .addHelpText(
+    "after",
+    `
+Required:
+  --space and --api-key must be provided from args or env.
+
+Examples:
+  $ bklg auth login --space hgwr --api-key YOUR_API_KEY
+  $ bklg auth login --space hgwr --host backlog.com --api-key YOUR_API_KEY
+`,
+  )
   .action(
     withOutputFormat(async (format) => {
     const opts = program.opts<{ space?: string; host?: string; apiKey?: string }>();
@@ -311,7 +343,16 @@ auth
 
 auth
   .command("status")
-  .description("Show current auth settings")
+  .description("Show current auth settings (API key is masked)")
+  .usage("[options]")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  $ bklg auth status
+  $ bklg auth status --format md
+`,
+  )
   .action(
     withOutputFormat(async (format) => {
     const opts = program.opts<{ space?: string; host?: string; apiKey?: string }>();
@@ -329,6 +370,15 @@ auth
 auth
   .command("logout")
   .description("Remove stored API key")
+  .usage("[options]")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  $ bklg auth logout
+  $ bklg auth logout --format md
+`,
+  )
   .action(
     withOutputFormat(async (format) => {
     const result = await logout();
@@ -343,7 +393,16 @@ auth
 issue
   .command("view")
   .description("View an issue by key or id")
+  .usage("<issueKeyOrId> [options]")
   .argument("<issueKeyOrId>", "Issue key (PROJ-123) or numeric id")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  $ bklg issue view PROJ-123
+  $ bklg issue view 12345 --format md
+`,
+  )
   .action(async (issueKeyOrId: string) => {
     const context = await resolveCommandContext();
     if (!context) {
@@ -362,7 +421,16 @@ issue
 issue
   .command("comments")
   .description("List issue comments")
+  .usage("<issueKeyOrId> [options]")
   .argument("<issueKeyOrId>", "Issue key (PROJ-123) or numeric id")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  $ bklg issue comments PROJ-123 --format text
+  $ bklg issue comments 12345 --format md
+`,
+  )
   .action(async (issueKeyOrId: string) => {
     const context = await resolveCommandContext();
     if (!context) {
@@ -381,11 +449,25 @@ issue
 issue
   .command("writeComment")
   .description("Write a comment to an issue")
+  .usage("<issueKeyOrId> (-m <text> | --message-file <path>) [options]")
   .argument("<issueKeyOrId>", "Issue key (PROJ-123) or numeric id")
   .addOption(new Option("-m, --message <text>", "comment content").conflicts("messageFile"))
   .addOption(new Option("--message-file <path>", "comment content file").conflicts("message"))
   .option("--notify <userIdCSV>", "notify user IDs (comma-separated)")
   .option("--dry-run", "show comment without posting", false)
+  .addHelpText(
+    "after",
+    `
+Notes:
+  --message and --message-file are mutually exclusive.
+  --notify accepts comma-separated numeric Backlog user IDs.
+
+Examples:
+  $ bklg issue writeComment PROJ-123 -m "Please review"
+  $ bklg issue writeComment PROJ-123 --message-file ./comment.md --notify 1001,1002
+  $ bklg issue writeComment PROJ-123 -m "draft only" --dry-run --format md
+`,
+  )
   .action(async (issueKeyOrId: string, writeOpts: WriteCommentOptions) => {
     const context = await resolveCommandContext();
     if (!context) {
@@ -439,6 +521,7 @@ issue
 issue
   .command("search")
   .description("Search issues")
+  .usage("[options]")
   .option("--project <projectId>", "project id (repeatable)", collectValues, [])
   .option("--status <statusId>", "status id (numeric)")
   .option("--assignee <assignee>", "assignee id (numeric) or 'me'")
@@ -447,6 +530,18 @@ issue
   .option("--offset <n>", "offset", parseNumberOption)
   .option("--sort <created|updated|dueDate>", "sort field")
   .option("--order <asc|desc>", "sort order")
+  .addHelpText(
+    "after",
+    `
+Notes:
+  --project can be repeated: --project 1 --project 2
+  --status and numeric --assignee use Backlog IDs.
+
+Examples:
+  $ bklg issue search --project 123 --status 1 --assignee me --format md
+  $ bklg issue search --keyword "login" --count 20 --order desc --format text
+`,
+  )
   .action(async (searchOpts: SearchOptions) => {
     const context = await resolveCommandContext();
     if (!context) {
@@ -471,8 +566,17 @@ issue
 wiki
   .command("view")
   .description("View a wiki page by name")
+  .usage("<pageName> --project <projectKeyOrId> [options]")
   .argument("<pageName>", "Wiki page name")
   .requiredOption("--project <projectKey>", "Project key for the wiki")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  $ bklg wiki view "Wiki Page" --project PROJ --format md
+  $ bklg wiki view "API Rules" --project 123 --format json
+`,
+  )
   .action(async (pageName: string, opts: { project: string }) => {
     const context = await resolveCommandContext();
     if (!context) {


### PR DESCRIPTION
## Summary
Improve `bklg` help output (`-h`/`--help`) so users and AI agents can quickly discover required inputs, global options, and concrete examples.

## Changes
- Enabled global option rendering in subcommand help via Commander `configureHelp({ showGlobalOptions: true })`
- Added root help appendix with:
  - auth resolution order (args/env/config)
  - output format guidance (`md|json|text`)
  - practical examples
- Expanded per-command help with usage/examples/notes for:
  - `auth login/status/logout`
  - `issue view/comments/writeComment/search`
  - `wiki view`
- Clarified option descriptions for auth-related global options (`--space`, `--host`, `--api-key`)
- Updated docs:
  - `docs/spec.md` help output expectations
  - `README.md` / `README-ja.md` help usage tips

## Verification
- `npm run -s build`
- Manually checked:
  - `node dist/cli/index.js -h`
  - `node dist/cli/index.js auth login -h`
  - `node dist/cli/index.js issue search -h`

## Notes
- `npm run -s lint` fails on pre-existing repository issues unrelated to this change:
  - `eslint.config.cjs`: `@typescript-eslint/no-require-imports`
  - `src/auth/index.ts`: unused variable
  - `src/format/index.ts`: unused variable

Closes #19
